### PR TITLE
PTS 实现

### DIFF
--- a/calibrator/pts.py
+++ b/calibrator/pts.py
@@ -1,0 +1,172 @@
+import os
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import TensorDataset, DataLoader
+import numpy as np
+from calibrator.calibrator import Calibrator
+
+class PTSCalibrator(Calibrator):
+    """
+    PyTorch implementation of Parameterized Temperature Scaling (PTS)
+    """
+    def __init__(self, epochs, lr, weight_decay, batch_size, nlayers, n_nodes, length_logits, top_k_logits):
+        """
+        Args:
+            epochs (int): Number of epochs for PTS model tuning
+            lr (float): Learning rate
+            weight_decay (float): Weight decay coefficient (L2 regularization)
+            batch_size (int): Batch size for training
+            nlayers (int): Number of fully connected layers in PTS model
+            n_nodes (int): Number of nodes in each hidden layer
+            length_logits (int): Length of input logits
+            top_k_logits (int): Number of top k elements to use from sorted logits
+        """
+        super(PTSCalibrator, self).__init__()
+        self.epochs = epochs
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.batch_size = batch_size
+        self.nlayers = nlayers
+        self.n_nodes = n_nodes
+        self.length_logits = length_logits
+        self.top_k_logits = top_k_logits
+
+        # Build parameterized temperature branch: input is top k sorted logits
+        layers = []
+        input_dim = top_k_logits
+        if self.nlayers > 0:
+            # First layer
+            layers.append(nn.Linear(input_dim, self.n_nodes))
+            layers.append(nn.ReLU())
+            # Subsequent hidden layers
+            for _ in range(self.nlayers - 1):
+                layers.append(nn.Linear(self.n_nodes, self.n_nodes))
+                layers.append(nn.ReLU())
+            # Final output layer: outputs scalar temperature
+            layers.append(nn.Linear(self.n_nodes, 1))
+        else:
+            # If no hidden layers, directly map from top_k_logits to 1 number
+            layers.append(nn.Linear(input_dim, 1))
+        self.temp_branch = nn.Sequential(*layers)
+        
+        # Note: Since PyTorch's weight decay is set in the optimizer,
+        # we don't need to specify regularization in each fully connected layer
+
+    def forward(self, input_logits):
+        """
+        Forward pass:
+          1. Sort input logits in descending order and take top k elements;
+          2. Pass the selected elements through the fully connected network to get scalar temperature (with abs and clip);
+          3. Divide original logits by the temperature and apply softmax to get calibrated probability distribution.
+        """
+        # Input shape: (batch_size, length_logits)
+        # Sort logits in descending order
+        sorted_logits, _ = torch.sort(input_logits, dim=1, descending=True)
+        # Take top k elements
+        topk = sorted_logits[:, :self.top_k_logits]  # shape: (batch_size, top_k_logits)
+        
+        # Get temperature through fully connected network (output shape: (batch_size, 1))
+        t = self.temp_branch(topk)
+        temperature = torch.abs(t)
+        # Clip temperature to prevent division by zero or large values
+        temperature = torch.clamp(temperature, min=1e-12, max=1e12)
+        # Use broadcasting to apply temperature to all logits
+        adjusted_logits = input_logits / temperature
+        # Output softmax probability distribution
+        calibrated_probs = F.softmax(adjusted_logits, dim=1)
+        return calibrated_probs, adjusted_logits
+
+    def fit(self, val_logits, val_labels, **kwargs):
+        """
+        Tune (train) the PTS model
+        
+        Args:
+            val_logits (np.array or torch.Tensor): shape (N, length_logits)
+            val_labels (np.array or torch.Tensor): shape (N, length_logits)
+                (Using MSE loss, so labels are typically one-hot encoded probability distributions)
+            **kwargs: Optional additional parameters
+                - clip (float): Clipping threshold for logits, defaults to 1e2
+        """
+        clip = kwargs.get('clip', 1e2)
+        
+        # Convert to tensor if input is not already a tensor (float type)
+        if not torch.is_tensor(val_logits):
+            val_logits = torch.tensor(val_logits, dtype=torch.float32)
+        if not torch.is_tensor(val_labels):
+            val_labels = torch.tensor(val_labels, dtype=torch.float32)
+        
+        # Check input dimensions
+        assert val_logits.size(1) == self.length_logits, "Logits length must match length_logits!"
+        assert val_labels.size(1) == self.length_logits, "Labels length must match length_logits!"
+        
+        # Clip logits
+        val_logits = torch.clamp(val_logits, min=-clip, max=clip)
+        
+        # Create DataLoader
+        dataset = TensorDataset(val_logits, val_labels)
+        dataloader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+        
+        # Define MSE loss function and Adam optimizer (weight_decay implements L2 regularization)
+        criterion = nn.MSELoss()
+        optimizer = torch.optim.Adam(self.parameters(), lr=self.lr, weight_decay=self.weight_decay)
+        
+        self.train()
+        for epoch in range(self.epochs):
+            epoch_loss = 0.0
+            for batch_logits, batch_labels in dataloader:
+                optimizer.zero_grad()
+                outputs, _ = self.forward(batch_logits)
+                loss = criterion(outputs, batch_labels)
+                loss.backward()
+                optimizer.step()
+                epoch_loss += loss.item() * batch_logits.size(0)
+            epoch_loss /= len(dataset)
+            print(f"Epoch {epoch + 1}/{self.epochs}, Loss: {epoch_loss:.4f}")
+    
+    def calibrate(self, test_logits, return_logits=False, **kwargs):
+        """
+        Calibrate logits using the trained PTS model
+        
+        Args:
+            test_logits (np.array or torch.Tensor): shape (N, length_logits)
+            return_logits (bool): Whether to return calibrated logits, defaults to False
+            **kwargs: Optional additional parameters
+                - clip (float): Clipping threshold, defaults to 1e2
+        Return:
+            If return_logits is False, returns calibrated probability distribution (np.array)
+            If return_logits is True, returns calibrated logits (np.array)
+        """
+        clip = kwargs.get('clip', 1e2)
+        
+        if not torch.is_tensor(test_logits):
+            test_logits = torch.tensor(test_logits, dtype=torch.float32)
+        
+        assert test_logits.size(1) == self.length_logits, "Logits length must match length_logits!"
+        test_logits = torch.clamp(test_logits, min=-clip, max=clip)
+        
+        self.eval()
+        with torch.no_grad():
+            calibrated_probs, calibrated_logits = self.forward(test_logits)
+            
+        if return_logits:
+            return calibrated_logits.cpu().numpy()
+        return calibrated_probs.cpu().numpy()
+    
+    def save(self, path="./"):
+        """
+        Save PTS model parameters
+        """
+        if not os.path.exists(path):
+            os.makedirs(path)
+        save_path = os.path.join(path, "pts_model.pth")
+        torch.save(self.state_dict(), save_path)
+        print("Save PTS model to:", save_path)
+    
+    def load(self, path="./"):
+        """
+        Load PTS model parameters
+        """
+        load_path = os.path.join(path, "pts_model.pth")
+        self.load_state_dict(torch.load(load_path, map_location=torch.device('cpu')))
+        print("Load PTS model from:", load_path)

--- a/tests/test_pts_calibrator.py
+++ b/tests/test_pts_calibrator.py
@@ -1,0 +1,94 @@
+from calibrator.metrics import ECE
+
+def test_pts_calibrator():
+    print("---Test PTS Calibrator---")
+
+    from calibrator import PTSCalibrator
+    import torch
+    import numpy as np
+
+    # Load validation and test data
+    val_logits, val_labels = torch.load("tests/test_logits/resnet50_cifar10_cross_entropy_val_0.1_vanilla.pt", weights_only=False)
+    test_logits, test_labels = torch.load("tests/test_logits/resnet50_cifar10_cross_entropy_test_0.9_vanilla.pt", weights_only=False)
+
+    # Get the number of classes from the logits shape
+    num_classes = val_logits.shape[1]
+
+    # Initialize the PTS calibrator with appropriate parameters
+    calibrator = PTSCalibrator(
+        epochs=10,                # Number of training epochs
+        lr=0.01,                 # Learning rate
+        weight_decay=1e-4,       # L2 regularization
+        batch_size=64,           # Batch size for training
+        nlayers=2,               # Number of fully connected layers
+        n_nodes=32,              # Number of nodes in each hidden layer
+        length_logits=num_classes,  # Length of input logits (number of classes)
+        top_k_logits=5           # Number of top k elements to use from sorted logits
+    )
+
+    # Fit the calibrator on validation data
+    calibrator.fit(val_logits, val_labels)
+
+    # Calibrate the test logits
+    calibrated_probability = calibrator.calibrate(test_logits)
+
+    # Calculate and print ECE metrics
+    uncalibrated_ece = ECE()(labels=test_labels, logits=test_logits)
+    calibrated_ece = ECE()(labels=test_labels, softmaxes=calibrated_probability)
+
+    print(f"Uncalibrated ECE: {uncalibrated_ece:.4f}")
+    print(f"Calibrated ECE: {calibrated_ece:.4f}")
+    
+    # Verify that calibration improved the ECE
+    assert calibrated_ece < uncalibrated_ece, "Calibration should improve ECE"
+    
+    # Test saving and loading the model
+    import os
+    import tempfile
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Save the model
+        calibrator.save(temp_dir)
+        
+        # Create a new calibrator instance
+        new_calibrator = PTSCalibrator(
+            epochs=10,
+            lr=0.01,
+            weight_decay=1e-4,
+            batch_size=64,
+            nlayers=2,
+            n_nodes=32,
+            length_logits=num_classes,
+            top_k_logits=5
+        )
+        
+        # Load the saved model
+        new_calibrator.load(temp_dir)
+        
+        # Calibrate with the loaded model
+        loaded_calibrated_probability = new_calibrator.calibrate(test_logits)
+        
+        # Verify that the loaded model produces the same results
+        np.testing.assert_array_almost_equal(
+            calibrated_probability, 
+            loaded_calibrated_probability, 
+            decimal=5, 
+            err_msg="Loaded model should produce the same calibration results"
+        )
+    
+    # Test calibrate with return_logits=True
+    calibrated_logits = calibrator.calibrate(test_logits, return_logits=True)
+    
+    # Verify that the returned logits can be converted to the same probabilities
+    manual_calibrated_probs = torch.nn.functional.softmax(torch.tensor(calibrated_logits), dim=1).numpy()
+    np.testing.assert_array_almost_equal(
+        calibrated_probability, 
+        manual_calibrated_probs, 
+        decimal=5, 
+        err_msg="Manual softmax of returned logits should match calibrated probabilities"
+    )
+    
+    print("!!! Pass PTS Calibrator Test !!!")
+
+if __name__ == "__main__":
+    test_pts_calibrator()


### PR DESCRIPTION
新增 PTSCalibrator 类，通过一个多层全连接网络对 logits 的 top k 值生成动态温度参数，实现模型输出概率的校准。

在 forward 方法中，先对 logits 排序并取前 k 个，再由网络生成温度（经过绝对值和 clip 处理），用于缩放 logits 后计算 softmax 分布。

fit 方法使用 MSE 损失和 Adam 优化器训练模型，并支持将类别索引转换为 one-hot 编码。

同时新增 calibrate、save 与 load 方法，实现校准应用、参数保存与加载。